### PR TITLE
Change newlines to <br> tags in table cell content.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,13 @@ function addProps(props, options) {
     ...keys
       .map((key) => {
         const prop = filteredProps[key];
-        return [getKey(key, prop.type), getTypeName(prop.type), getDefaultValue(prop), prop.required, prop.description];
+        const row = [getKey(key, prop.type), getTypeName(prop.type), getDefaultValue(prop), prop.required, prop.description];
+        return row.map((rowValue) => {
+          if (typeof rowValue === 'string') {
+            return rowValue.split('\n').join('<br>');
+          }
+          return rowValue;
+        });
       }
     ),
   ];


### PR DESCRIPTION
Hi,

Came across a problem where newlines in table cells (multi-line content) was breaking rendering (on github). Substituting newlines with `<br>` tags fixes this.

Here is an example of the issue:

1. [Generated markdown](https://github.com/twisty/formsy-react-components/blob/v1.0.0-alpha.1/docs/api/textarea.md)
2. [JS source file](https://github.com/twisty/formsy-react-components/blob/v1.0.0-alpha.1/src/components/textarea.js)
3. ([Generator script](https://github.com/twisty/formsy-react-components/blob/v1.0.0-alpha.1/generate-api-docs.sh))