### PR TITLE
Add flowtype support

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,9 +1,13 @@
 import kebab from 'lodash/fp/kebabCase'
 import capitalize from 'lodash/fp/capitalize'
 
+export function getType(prop) {
+  return prop.type || prop.flowType
+}
+
 export function getDefaultValue(prop) {
   const value = prop.defaultValue
-  const type = prop.type.name
+  const type = getType(prop).name
   if (!value) {
     switch (type) {
       case 'bool':
@@ -68,14 +72,14 @@ export function filterProps(
   prop,
   { excludeKey, excludeType, excludeDescription },
 ) {
-  if (!prop.type) {
+  if (!getType(prop)) {
     // eslint-disable-next-line no-console
     console.error(
       `Found prop '${name}' without type. Has it been removed, but left in 'defaultProps'?`,
     )
   }
   if (excludeKey && excludeKey.test(name)) return false
-  if (excludeType && prop.type && excludeType.test(prop.type.name || prop.type))
+  if (excludeType && getType(prop) && excludeType.test(getType(prop).name))
     return false
   if (excludeDescription && excludeDescription.test(prop.description))
     return false

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import table from 'markdown-table'
-import { getDefaultValue, getKey, getTypeName, filterProps } from './helpers'
+import { getDefaultValue, getKey, getType, getTypeName, filterProps } from './helpers'
 import { describeSubTypes } from './types'
 
 const TABLE_HEADERS = ['Name', 'Type', 'Default', 'Required', 'Description']
@@ -27,8 +27,8 @@ function addProps(props, options) {
     ...keys.map(key => {
       const prop = filteredProps[key]
       const row = [
-        getKey(key, prop.type),
-        getTypeName(prop.type),
+        getKey(key, getType(prop)),
+        getTypeName(getType(prop)),
         getDefaultValue(prop),
         prop.required,
         prop.description,

--- a/src/types.js
+++ b/src/types.js
@@ -1,5 +1,5 @@
 import table from 'markdown-table'
-import { getKey, getTypeName, isComplexType, blockquote } from './helpers'
+import { getKey, getType, getTypeName, isComplexType, blockquote } from './helpers'
 
 export function describeType(type, level = 0) {
   switch (type.name) {
@@ -26,7 +26,7 @@ export function describeSubTypes(types, level = 0) {
   keys.forEach(key => {
     const prop = types[key]
     // Type can either be on the prop, or in the type field depending on depth.
-    const type = prop.type || prop
+    const type = getType(prop) || prop
 
     if (isComplexType(type.name)) {
       const result = describeType(type, level)


### PR DESCRIPTION
When using react-docs-markdown on json output from docgen with flowType, it wasn't able to find the types because the type field is `flowType`. Now it checks for first `type` and then `flowType`.